### PR TITLE
Enhancement: Divider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules
 dist
 .yalc
+
+*.sw*

--- a/src/components/Divider/index.tsx
+++ b/src/components/Divider/index.tsx
@@ -1,12 +1,29 @@
 import React from 'react';
 import { View as RNView, ViewProps as RNViewProps } from 'react-native';
 
-import { space, SpaceProps, border, BorderProps } from 'styled-system';
+import {
+  space,
+  SpaceProps,
+  border,
+  BorderProps,
+  BorderStyleProps,
+} from 'styled-system';
 import styled from '@emotion/native';
 
-export type DividerProps = SpaceProps & BorderProps & RNViewProps;
+export type DividerProps = SpaceProps &
+  BorderProps &
+  RNViewProps & {
+    size?: number;
+    color?: string;
+    type?: BorderStyleProps['borderStyle'];
+  };
 
-const Divider = ({ size = 1, color = 'black', type = 'solid', ...props }) => {
+const Divider = ({
+  size = 1,
+  color = 'black',
+  type = 'solid',
+  ...props
+}: DividerProps) => {
   const BaseView = styled(RNView)<DividerProps>`
     ${space}
     ${border}


### PR DESCRIPTION
## What's in this diff?
Extends typing on Divider component. `type` props now has a more specific suggestion

before:
<img width="162" alt="image" src="https://user-images.githubusercontent.com/23289654/165455195-da88c359-07b6-4f53-95d8-83e252816c09.png">


now:
<img width="185" alt="image" src="https://user-images.githubusercontent.com/23289654/165452266-cf13bb53-bc79-43be-9001-12e3420acd45.png">
