### PR TITLE
Enhancement: Image component source

### DIFF
--- a/example/components/Image/Image.stories.tsx
+++ b/example/components/Image/Image.stories.tsx
@@ -12,6 +12,8 @@ export default {
   component: Image,
 } as ComponentMeta<typeof Image>;
 
+import WP from './assets/images/WP.png';
+
 export const URI: ComponentStory<typeof Image> = args => (
   <Showcase>
     <ShowcaseSection title="Image" subtitle="Image with URL">
@@ -102,7 +104,7 @@ URI.args = {
 };
 
 LocalPath.args = {
-  source: require('../Image/assets/images/WP.png'),
+  source: WP,
 };
 
 WithBorder.args = {

--- a/example/global.d.ts
+++ b/example/global.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+  const value: import('react-native').ImageSourcePropType;
+  export default value;
+}

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -20,9 +20,6 @@ export type ImageProps = LayoutProps &
     withProxy?: boolean;
     height: string | number;
     width: string | number;
-    source: {
-      uri: string;
-    };
   };
 
 const Image = (props: ImageProps) => {


### PR DESCRIPTION
## What's in this PR?
 - `source` prop of Image's typing now is derived from ReactNative's `ImageProps`. Previously `source` only accepts 
 ```ts
{ uri: string }
```
. This causes an issue where embedding image locally from repository will make linter unhappy 😕
<img width="217" alt="image" src="https://user-images.githubusercontent.com/23289654/184098458-b3749f0d-7a3f-4603-819c-f5b039efef86.png">
